### PR TITLE
Schema introspection with auth headers blows up

### DIFF
--- a/strawberry_django_jwt/middleware.py
+++ b/strawberry_django_jwt/middleware.py
@@ -27,7 +27,7 @@ def allow_any(info, **kwargs):
 
     if field is None:
         return False
-    
+
     field_type = getattr(field.type, "of_type", None)
 
     return field_type is not None and any(

--- a/strawberry_django_jwt/middleware.py
+++ b/strawberry_django_jwt/middleware.py
@@ -25,6 +25,9 @@ __all__ = [
 def allow_any(info, **kwargs):
     field = info.parent_type.fields.get(info.field_name)
 
+    if field is None:
+        return False
+    
     field_type = getattr(field.type, "of_type", None)
 
     return field_type is not None and any(


### PR DESCRIPTION
Schema introspection does not have any fields with it so we should short circuit instead of blowing up on `field.type`. This allows the schema to be introspected when auth headers are set in clients like graphql playground or insomnia.

This is just a quick fix I found, not sure if it is 100% correct!