### PR TITLE
fix error RefreshedTokenType.__init__() takes 1 positional argument …

### DIFF
--- a/strawberry_django_jwt/mixins.py
+++ b/strawberry_django_jwt/mixins.py
@@ -151,7 +151,7 @@ class RefreshTokenMixin(JSONWebTokenMixin):
             refresh_token=old_refresh_token,
             refresh_token_issued=new_refresh_token,
         )
-        return RefreshedTokenType(payload, token, new_refresh_token, refresh_expires_in=0)
+        return RefreshedTokenType(payload=payload, token=token, refresh_token=new_refresh_token, refresh_expires_in=0)
 
     def refresh(self, info: Info, refresh_token: Optional[str] = None) -> RefreshedTokenType:
         return RefreshTokenMixin._refresh(self, info=info, refresh_token=refresh_token)


### PR DESCRIPTION
Hey guys!

With strawberry-graphql = "0.128.0" I get the error

```
File "strawberry_django_jwt/mixins.py", line 154, in _refresh
    return RefreshedTokenType(payload, token, new_refresh_token, refresh_expires_in=0)
TypeError: RefreshedTokenType.__init__() takes 1 positional argument but 4 positional arguments (and 1 keyword-only argument) were given
```
This commit fixes one